### PR TITLE
Goto /home/pi after installing node.js

### DIFF
--- a/getting-started/installation.html.md
+++ b/getting-started/installation.html.md
@@ -31,6 +31,7 @@ You must have the `gcc` compiler or some other suitable compiler installed. On D
 
 Once node.js and npm are installed you can run
 
+    cd /home/pi
     mkdir pimatic-app
     npm install pimatic --prefix pimatic-app --production
 


### PR DESCRIPTION
after installing node.js people are in /usr/local and when just continuing they install pimatic there.
Had several people that couldn't find pimatic-app because after reboot they are in /home/pi.